### PR TITLE
chore: Refactor download_repo function to support GitLab repositories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+venv/
+pharmaink.git_python.txt
+pharmaink.git_symfony.txt


### PR DESCRIPTION
Added gitlab.com support auto detected depens on the url you providing.

for private repo added arg : --token

For use with private repo :

python github2file.py https://github.com/<USERNAME>/github2file --token <YOUR_PERSONAL_ACCESS_TOKEN>


